### PR TITLE
Change "field_definition" attribute to "field_definitions" in config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ csvdedupe examples/csv_example_messy_input.csv \
 ```json
 {
   "field_names": ["Site name", "Address", "Zip", "Phone"],
-  "field_definition" : [{"field" : "Site name", "type" : "String"},
+  "field_definitions" : [{"field" : "Site name", "type" : "String"},
                         {"field" : "Address", "type" : "String"},
                         {"field" : "Zip", "type" : "String",
                          "Has Missing" : true},
@@ -134,7 +134,7 @@ csvdedupe examples/restaurant-1.csv examples/restaurant-2.csv \
 {
   "field_names_1": ["name", "address", "city", "cuisine"],
   "field_names_2": ["restaurant", "street", "city", "type"],
-  "field_definition" : [{"field" : "name", "type" : "String"},
+  "field_definitions" : [{"field" : "name", "type" : "String"},
                         {"field" : "address", "type" : "String"},
                         {"field" : "city", "type" : "String",
                          "Has Missing" : true},

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,7 @@ Example config file
 
     {
       "field_names": ["Site name", "Address", "Zip", "Phone"],
-      "field_definition" : {"Site name" : {"type" : "String"},
+      "field_definitions" : {"Site name" : {"type" : "String"},
                             "Address"   : {"type" : "String"},
                             "Zip"       : {"type" : "String",
                                            "Has Missing" : true},
@@ -136,7 +136,7 @@ Example config file
     {
       "field_names_1": ["name", "address", "city", "cuisine"],
       "field_names_2": ["restaurant", "street", "city", "type"],
-      "field_definition" : {"name":    {"type" : "String"},
+      "field_definitions" : {"name":    {"type" : "String"},
                             "address": {"type" : "String"},
                             "city":    {"type" : "String",
                                         "Has Missing" : true},

--- a/examples/config.json.example
+++ b/examples/config.json.example
@@ -1,6 +1,6 @@
 {
   "field_names": ["Site name","Address","Zip","Phone"],
-  "field_definition" : {"Site name" : {"type" : "String"},
+  "field_definitions" : {"Site name" : {"type" : "String"},
                         "Address"   : {"type" : "String"},
                         "Zip"       : {"type" : "String",
 				       "Has Missing" : true},


### PR DESCRIPTION
I received this error when using `csvdedupe` and having a `config.json` with a `field_definition` attribute:

```
Traceback (most recent call last):
  File "/Users/williamsa/.envs/superpac-2016/bin/csvdedupe", line 11, in <module>
    sys.exit(launch_new_instance())
  File "/Users/williamsa/.envs/superpac-2016/lib/python2.7/site-packages/csvdedupe/csvdedupe.py", line 161, in launch_new_instance
    d = CSVDedupe()
  File "/Users/williamsa/.envs/superpac-2016/lib/python2.7/site-packages/csvdedupe/csvdedupe.py", line 50, in __init__
    for field_def in self.field_definitions]
```

I solved it by changing `field_definition` to `field_definitions` in `config.json`. I've updated the README, docs and example config.json with the new attribute. Let me know if this is in error. Thanks!